### PR TITLE
Fixed, model was not called p in view, it was called item because tha…

### DIFF
--- a/APixelADay/Views/Gallery/Gallery.cshtml
+++ b/APixelADay/Views/Gallery/Gallery.cshtml
@@ -50,8 +50,8 @@
                 @Html.DisplayFor(modelItem => item.Dimensions)
             </td>
             <td>
-                <!--At Symbol p.ProductID does not work, it produces a "p does not exist in this context" error.-->
-                <a class="btn btn-secondary" asp-route-id="" asp-action="Edit">Edit</a>
+                
+                <a class="btn btn-secondary" asp-route-id="@item.PixelArtID" asp-action="Edit">Edit</a>
             </td>
             
         </tr>


### PR DESCRIPTION
…ts what VS Code generated the variable as when the page was created. Edit now functions properly. Closes #81 